### PR TITLE
Calculate content-length in bytes, not codepoints

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -98,7 +98,8 @@ merge(Client.prototype, {
 
   _insertContentLength: function(headers, data) {
     if (data) {
-      headers['Content-Length'] = JSON.stringify(data).length;
+      var jsonContent = JSON.stringify(data)
+      headers['Content-Length'] = Buffer.byteLength(jsonContent, 'utf8');
     }
   }
 });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -98,8 +98,8 @@ merge(Client.prototype, {
 
   _insertContentLength: function(headers, data) {
     if (data) {
-      var jsonContent = JSON.stringify(data)
-      headers['Content-Length'] = Buffer.byteLength(jsonContent, 'utf8');
+      var body = serializer.dump(data);
+      headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
     }
   }
 });


### PR DESCRIPTION
`String.length` returns the length in codepoints, not bytes, but `Content-Length` must count bytes, so whenever there are non-ascii characters in the JSON, the `Content-Length` is short some bytes, causing potential incomplete parsing at the server end. 

[Node Buffer.byteLength docs](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding)