### PR TITLE
GET requests via Client.js retain any Content-Length value from previous requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ var instance   = delighted('DUMMY_API_KEY', {
 });
 
 var mapping = {
-  '/people': {
+  'POST /v1/people': {
     status: 201,
-    body: { email: 'foo@example.com' }
+    body: { id: "1", email: 'foo@example.com', name: null, survey_scheduled_at: 1490298348 }
   }
 };
 
@@ -121,9 +121,20 @@ var server = mockServer(5678, mapping);
 Setting up the server only requires a port and a mapping. The mapping should match an exact endpoint and will send back a JSON body with the specified status code. With the server running you can then make a request:
 
 ```javascript
-instance.person.create({ email: 'foo@example.com' }).then(function(response) {
-  console.log(response); //=> { email: 'foo@exampe.com' }
-});
+instance.person.create({ email: 'foo@example.com' }).then(
+  function(person) {
+    console.log(person.survey_scheduled_at); //=> 1490298348
+  },
+  function(error) {
+    console.log(error.type); //=> ResourceValidationError
+  }
+);
+```
+
+When you are done reading responses from the server, be sure to close it.
+
+```javascript
+server.close();
 ```
 
 ## Contributing

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -100,7 +100,7 @@ merge(Client.prototype, {
     return {
       hostname: this.host,
       port:     this.port,
-      headers:  Object.assign({}, this.headers),
+      headers:  this._cloneObject(this.headers),
       path:     this.base + path,
       method:   method
     };
@@ -111,6 +111,21 @@ merge(Client.prototype, {
       var body = serializer.dump(data);
       headers['Content-Length'] = Buffer.byteLength(body, 'utf8');
     }
+  },
+
+  _cloneObject: function() {
+    var target = {};
+
+    for (var i = 0; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var name in source) {
+        if (source.hasOwnProperty(name)) {
+          target[name] = source[name];
+        }
+      }
+    }
+
+    return target;
   }
 });
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -100,7 +100,7 @@ merge(Client.prototype, {
     return {
       hostname: this.host,
       port:     this.port,
-      headers:  this.headers,
+      headers:  Object.assign({}, this.headers),
       path:     this.base + path,
       method:   method
     };

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -70,6 +70,18 @@ describe('Client', function() {
         expect(response.body).to.eql({ ok: true });
       });
     });
+
+    it('does not modify client default headers', function() {
+      var config = Object.assign(
+        {}, helper.config, { headers: { 'User-Agent': 'header test' } }
+      );
+      var originalHeaders = Object.assign({}, config.headers);
+      var client = new Client(config);
+
+      return client.post('/201', { ok: true }).then(function(response) {
+        expect(client.headers).to.eql(originalHeaders);
+      });
+    });
   });
 
   describe('#put', function() {

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -72,10 +72,16 @@ describe('Client', function() {
     });
 
     it('does not modify client default headers', function() {
-      var config = Object.assign(
-        {}, helper.config, { headers: { 'User-Agent': 'header test' } }
-      );
-      var originalHeaders = Object.assign({}, config.headers);
+      var originalHeaders = { 'User-Agent': 'header test' };
+      var clone = function(source) {
+        var target = {};
+        for (var name in source) {
+          if (source.hasOwnProperty(name)) { target[name] = source[name]; }
+        }
+        return target;
+      }
+      var config = clone(helper.config);
+      config.headers = clone(originalHeaders);
       var client = new Client(config);
 
       return client.post('/201', { ok: true }).then(function(response) {


### PR DESCRIPTION
The headers object appears to be shared for all requests, and when a request has a body (such as a `create` call), it will set the `Content-Length` header. Once set in the shared headers object, when a `GET` request (such as an `all` call), it will remain in place, causing problems the server, which is waiting to receive the rest of the request content.