### PR TITLE
Prevent API key from leaking between instances when using default headers

### DIFF
--- a/lib/Delighted.js
+++ b/lib/Delighted.js
@@ -26,7 +26,7 @@ function Delighted(key, options) {
     host:    options.host    || DEFAULT_HOST,
     port:    options.port    || DEFAULT_PORT,
     base:    options.base    || DEFAULT_BASE,
-    headers: options.headers || DEFAULT_HEADERS,
+    headers: options.headers || Object.assign({}, DEFAULT_HEADERS),
     scheme:  options.scheme  || 'https'
   };
 

--- a/lib/Delighted.js
+++ b/lib/Delighted.js
@@ -26,7 +26,7 @@ function Delighted(key, options) {
     host:    options.host    || DEFAULT_HOST,
     port:    options.port    || DEFAULT_PORT,
     base:    options.base    || DEFAULT_BASE,
-    headers: options.headers || Object.assign({}, DEFAULT_HEADERS),
+    headers: options.headers || merge({}, DEFAULT_HEADERS),
     scheme:  options.scheme  || 'https'
   };
 

--- a/test/delighted_test.js
+++ b/test/delighted_test.js
@@ -41,5 +41,11 @@ describe('delighted', function() {
       expect(delighted.config.headers).to.have.property('Authorization');
       expect(delighted.config.headers['Authorization']).to.contain('Basic YWJjZDEyMzQ6');
     });
+
+    it('does leak API key into future instances', function() {
+      var a = new Delighted('foo');
+      var b = new Delighted('bar');
+      expect(a.config.headers.Authorization).to.not.equal(b.config.headers.Authorization);
+    });
   });
 });


### PR DESCRIPTION
Fixes #17 