### PR TITLE
Make sure error message is a string

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -80,7 +80,9 @@ merge(Client.prototype, {
             if (retryAfterHeader) {
               extraProperties.retryAfter = Number(retryAfterHeader);
             }
-            reject(errors(wrapper.status, wrapper.body, extraProperties));
+            const message = wrapper.body ? JSON.stringify(wrapper.body) : null;
+
+            reject(errors(wrapper.status, message, extraProperties));
           }
         });
       });

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -56,7 +56,7 @@ describe('Client', function() {
       }, function(error) {
         console.log('error', error);
         expect(error.type).to.eq('ResourceValidationError');
-        expect(error.message).to.eql({ data: 'an error occurred' });
+        expect(error.message).to.eq('{"data":"an error occurred"}');
       });
     });
 


### PR DESCRIPTION
This ensures the `message` in the Error object is actually a string and not a regular object. Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error the `message` should be human-readable, and from all the examples and descriptions, I think it can be understood to be a string.

We found that our error reporting stacks assumes it is a string, and it ends up as `[object Object]` in our error reports, which makes occasional errors very hard to debug.