### PR TITLE
fixed deprecated use of Buffer

### DIFF
--- a/lib/Delighted.js
+++ b/lib/Delighted.js
@@ -45,7 +45,7 @@ merge(Delighted.prototype, {
   },
 
   _injectAuthorization: function(key, headers) {
-    var base64Encoded = new Buffer(key + ':').toString('base64');
+    var base64Encoded = Buffer.from(key + ':').toString('base64'); 
 
     headers.Authorization = 'Basic ' + base64Encoded;
   },


### PR DESCRIPTION
`const buffer = new Buffer()` is deprecated. 
See [https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/)